### PR TITLE
Do not remove resources from observed state with regex

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -113,6 +113,10 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 					currentRegex, _ := getStrictRegex(string(r))
 					for k := range desiredComposed {
 						if currentRegex.MatchString(string(k)) {
+							if _, ok := observedComposed[k]; ok {
+								// if the resource is already part of the observedComposed, we should not delete it
+								continue
+							}
 							delete(desiredComposed, k)
 						}
 					}


### PR DESCRIPTION
### Description of your changes

When regex rules are used, the following check is not working as expected, leading to resources being deleted from the desired state although they have been created already.
https://github.com/twobiers/function-sequencer/blob/28bdf566e52c6337dab6d7b048f1f389860b42e0/fn.go#L68-L72

This change adds a sanity check before deleting anything from the desired state, so we can ensure we never delete resources that are already created.

Fixes #40 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
