### PR TITLE
Add support for resetting composite readiness indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ In other words, the following rules apply:
 
 See `example/composition-regex.yaml` for a complete example.
 
+### Composite Readiness
+Enabling the `resetCompositeReadiness` flag causes the function to set the Composite's `Ready` flag to `False` when at
+least one desired resource is deleted from the request. This prevents the Composite resource from entering the `Ready`
+state prematurely when there are pending resources that the composite reconciler is unaware of.
+
+```yaml
+  - step: sequence-creation
+    functionRef:
+      name: function-sequencer
+    input:
+      apiVersion: sequencer.fn.crossplane.io/v1beta1
+      kind: Input
+      resetCompositeReadiness: true
+      rules:
+        - sequence:
+          - first-subresource-.*
+          - second-resource
+```
 ## Installation
 
 It can be installed as follows from the Upbound marketplace: https://marketplace.upbound.io/functions/crossplane-contrib/function-sequencer

--- a/fn.go
+++ b/fn.go
@@ -119,6 +119,10 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 								continue
 							}
 							delete(desiredComposed, k)
+							if in.ResetCompositeReadiness {
+								// Reset the composite ready indicator to false when a desired resource is deleted.
+								rsp.Desired.Composite.Ready = v1.Ready_READY_FALSE
+							}
 						}
 					}
 					break

--- a/input/v1beta1/input.go
+++ b/input/v1beta1/input.go
@@ -30,6 +30,9 @@ type Input struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// ResetCompositeReadiness sets the composite ready state to false if desired resources are removed from the request.
+	// +kubebuilder:object:default=false
+	ResetCompositeReadiness bool `json:"resetCompositeReadiness,omitempty"`
 	// Rules is a list of rules that describe sequences of resources.
 	Rules []SequencingRule `json:"rules"`
 }

--- a/package/input/sequencer.fn.crossplane.io_inputs.yaml
+++ b/package/input/sequencer.fn.crossplane.io_inputs.yaml
@@ -38,6 +38,10 @@ spec:
             type: string
           metadata:
             type: object
+          resetCompositeReadiness:
+            description: ResetCompositeReadiness sets the composite ready state to
+              false if desired resources are removed from the request.
+            type: boolean
           rules:
             description: Rules is a list of rules that describe sequences of resources.
             items:


### PR DESCRIPTION
### Description of your changes
Add a flag to enable setting the Composite resource readiness indicator to False when a desired resource is deleted from the request.

Fixes: #78

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
