### PR TITLE
fix: bump Go to 1.26.2 to address stdlib CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.25.6'
+  GO_VERSION: '1.26.2'
   GOLANGCI_VERSION: 'v2.4.0'
   DOCKER_BUILDX_VERSION: 'v0.24.0'
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane/function-sequencer
 
-go 1.25.6
+go 1.26.2
 
 require (
 	github.com/alecthomas/kong v1.15.0


### PR DESCRIPTION
## Summary

This PR bumps the Go toolchain from **1.25.6 → 1.26.2** to resolve 5 confirmed vulnerabilities in the Go standard library, detected via `govulncheck`.

## Vulnerabilities Fixed

| ID | Package | Description | Severity |
|----|---------|-------------|----------|
| [GO-2026-4866](https://pkg.go.dev/vuln/GO-2026-4866) | `crypto/x509` | Case-sensitive `excludedSubtrees` name constraints → authentication bypass | High |
| [GO-2026-4870](https://pkg.go.dev/vuln/GO-2026-4870) | `crypto/tls` | Unauthenticated TLS 1.3 `KeyUpdate` record → persistent connection retention / DoS | High |
| [GO-2026-4865](https://pkg.go.dev/vuln/GO-2026-4865) | `html/template` | JsBraceDepth context tracking bug → XSS | Medium |
| [GO-2026-4947](https://pkg.go.dev/vuln/GO-2026-4947) | `crypto/x509` | Unexpected work during certificate chain building | Medium |
| [GO-2026-4946](https://pkg.go.dev/vuln/GO-2026-4946) | `crypto/x509` | Inefficient policy validation | Medium |

All call paths are reachable from this function (verified by govulncheck symbol-level analysis).

## Changes

- `go.mod`: `go 1.25.6` → `go 1.26.2`
- `.github/workflows/ci.yml`: `GO_VERSION: '1.25.6'` → `GO_VERSION: '1.26.2'`

## Verification

```
$ go test ./...
ok      github.com/crossplane/function-sequencer        0.655s

$ govulncheck ./...
No vulnerabilities found.
```

Signed-off-by: humoflife <markus.schweig@upbound.io>

🤖 Generated with [Claude Code](https://claude.com/claude-code)