### PR TITLE
feat: expose configurable gRPC max receive message size

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,10 +11,11 @@ import (
 type CLI struct {
 	Debug bool `help:"Emit debug logs in addition to info logs." short:"d"`
 
-	Network     string `default:"tcp"                                                                                        help:"Network on which to listen for gRPC connections."`
-	Address     string `default:":9443"                                                                                      help:"Address at which to listen for gRPC connections."`
-	TLSCertsDir string `env:"TLS_SERVER_CERTS_DIR"                                                                           help:"Directory containing server certs (tls.key, tls.crt) and the CA used to verify client certificates (ca.crt)"`
-	Insecure    bool   `help:"Run without mTLS credentials. If you supply this flag --tls-server-certs-dir will be ignored."`
+	Network            string `default:"tcp"                                                                                        help:"Network on which to listen for gRPC connections."`
+	Address            string `default:":9443"                                                                                      help:"Address at which to listen for gRPC connections."`
+	TLSCertsDir        string `env:"TLS_SERVER_CERTS_DIR"                                                                           help:"Directory containing server certs (tls.key, tls.crt) and the CA used to verify client certificates (ca.crt)"`
+	Insecure           bool   `help:"Run without mTLS credentials. If you supply this flag --tls-server-certs-dir will be ignored."`
+	MaxRecvMessageSize int    `default:"4"                                                                                          help:"Maximum size of received messages in MB."`
 }
 
 // Run this Function.
@@ -27,7 +28,8 @@ func (c *CLI) Run() error {
 	return function.Serve(&Function{log: log},
 		function.Listen(c.Network, c.Address),
 		function.MTLSCertificates(c.TLSCertsDir),
-		function.Insecure(c.Insecure))
+		function.Insecure(c.Insecure),
+		function.MaxRecvMessageSize(c.MaxRecvMessageSize*1024*1024))
 }
 
 func main() {


### PR DESCRIPTION
## Description

Adds a `--max-recv-message-size` CLI flag (value in MB, default `4`) that is wired through to `function.MaxRecvMessageSize` from the function SDK. This lets operators raise the gRPC server's max receive size when the function emits enough desired resources to exceed the default 4 MB cap.

When the deletion-ordering option is used on a sizeable pipeline, `function-sequencer` can produce a large desired-state payload. Crossplane then fails XR reconciliation with:

```
rpc error: code = ResourceExhausted desc = grpc: received message larger than max (10927406 vs. 4194304)
```

This matches the same flag added in [`function-template-go#91`](https://github.com/crossplane/function-template-go/pull/91) and aligns with the discussions in `function-auto-ready#47`, `crossplane#6392`, and `function-sdk-go#194`.

## Behavior

- New flag: `--max-recv-message-size` (int, MB, default `4`) — preserves existing behavior when unset.
- The value is multiplied by `1024 * 1024` and passed to `function.MaxRecvMessageSize`.

## Testing

- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...`

Fixes #135