### PR TITLE
feat/actionable sequencer

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,107 @@ those defined by pattern matching.  For example:
 creates a `Usage` resource for every resource that matches `first-subresource-*`, with `by` set to the `second-resource`.
 This ensures that `second-resource` is deleted before any of the `first-resource-*` resources are deleted.
 
+## Delete-Only Mode
+
+By default, sequencing rules enforce ordering for both resource creation and deletion (if `enableDeletionSequencing`).
+When `deleteOnly` is set to `true` on a rule, creation sequencing is skipped and resources are not blocked from being created,
+even if their predecessors aren't ready (think of it as "rely on eventual consistency" mode).
+Deletion ordering is still enforced via `Usage`/`ClusterUsage` resources when `enableDeletionSequencing` is also enabled.
+
+This is useful when you want to rely on eventual consistency for resource creation, but still need guaranteed deletion ordering.
+
+```yaml
+  - step: sequence-deletion-only
+    functionRef:
+      name: function-sequencer
+    input:
+      apiVersion: sequencer.fn.crossplane.io/v1beta1
+      kind: Input
+      enableDeletionSequencing: true
+      rules:
+        - sequence:
+          - vpc
+          - subnet
+          - security-group
+          deleteOnly: true
+```
+
+In the example above, `subnet` and `security-group` will be created immediately without waiting for predecessors.
+On deletion, `Usage` resources enforce the reverse order: `security-group` --> `subnet` --> `vpc`.
+
+The `deleteOnly` flag is per-rule, so you can mix creation-sequenced and delete-only rules in the same composition:
+
+```yaml
+      rules:
+        - sequence:
+          - vpc
+          - subnet
+        - sequence:
+          - subnet
+          - security-group
+          deleteOnly: true
+```
+
+## Conditional Sequences
+
+Rules can include a `condition` field containing a [CEL](https://github.com/google/cel-spec) (Common Expression Language) expression.
+When the condition evaluates to `false`, the entire sequence is skipped and no resources are blocked/removed from the desired state.
+
+This is useful when a sequence involves resources that are conditionally created based on the XR parameters.
+Without a condition, a resource that is never created would permanently block all successors in its sequence.
+
+```yaml
+  - step: sequence-creation
+    functionRef:
+      name: function-sequencer
+    input:
+      apiVersion: sequencer.fn.crossplane.io/v1beta1
+      kind: Input
+      enableDeletionSequencing: true
+      rules:
+        - sequence:
+          - vpc
+          - subnet
+        - sequence:
+          - subnet
+          - nat-gateway
+          condition: "observed.composite.resource.spec.enableNatGateway == true"
+```
+
+When `spec.enableNatGateway` is `false`, the second sequence is skipped entirely.
+The `nat-gateway` resource is not blocked, and it does not affect composite readiness.
+
+### CEL Variables
+
+The following variables are available in condition expressions, matching the conventions used by
+[function-cel-filter](https://github.com/crossplane-contrib/function-cel-filter):
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `observed` | `State` | The observed state of the composite and composed resources |
+| `desired` | `State` | The desired state as accumulated by prior pipeline steps |
+| `context` | `Struct` | The function pipeline context |
+
+Common access patterns:
+
+```cel
+observed.composite.resource.spec.someField == "value"
+desired.composite.resource.spec.count > 0
+size(observed.resources) > 0
+```
+
+### Safety: Observed Resource Protection
+
+When a condition evaluates to `false` but resources from the sequence already exist (they were created when the
+condition was previously `true`), deletion ordering is still enforced. `Usage`/`ClusterUsage` resources continue to
+be generated for observed resources regardless of the condition. This prevents resources from being deleted out of
+order when a condition changes at runtime.
+
+### CEL Environment
+
+The CEL environment is lazily initialized, thus there is zero overhead for compositions that do not use conditions.
+The environment is created once on first use and reused for subsequent evaluations.
+
 ## Installation
 
 The function can be installed into a Crossplane cluster using the following manifest:

--- a/README.md
+++ b/README.md
@@ -243,10 +243,11 @@ size(observed.resources) > 0
 
 ### Safety: Observed Resource Protection
 
-When a condition evaluates to `false` but resources from the sequence already exist (they were created when the
-condition was previously `true`), deletion ordering is still enforced. `Usage`/`ClusterUsage` resources continue to
-be generated for observed resources regardless of the condition. This prevents resources from being deleted out of
-order when a condition changes at runtime.
+When a condition evaluates to `false`, but resources from the sequence already exist (they were created when the condition was previously `true`),
+deletion ordering is still enforced.
+That is, (`Cluster`)`Usage` resources continue to be generated for observed resources, regardless of the condition.
+
+This prevents resources from being deleted out of order when a condition changes at runtime (e.g. a flaky condition).
 
 ### CEL Environment
 

--- a/example/composition-conditional.yaml
+++ b/example/composition-conditional.yaml
@@ -1,0 +1,65 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: function-sequencer-conditional
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+  - step: patch-and-transform
+    functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      resources:
+        - name: first-resource
+          base:
+            apiVersion: nop.crossplane.io/v1alpha1
+            kind: NopResource
+            spec:
+              forProvider:
+                conditionAfter:
+                  - time: 5s
+                    conditionType: Ready
+                    conditionStatus: "True"
+        - name: second-resource
+          base:
+            apiVersion: nop.crossplane.io/v1alpha1
+            kind: NopResource
+            spec:
+              forProvider:
+                conditionAfter:
+                  - time: 5s
+                    conditionType: Ready
+                    conditionStatus: "True"
+        - name: optional-resource
+          base:
+            apiVersion: nop.crossplane.io/v1alpha1
+            kind: NopResource
+            spec:
+              forProvider:
+                conditionAfter:
+                  - time: 5s
+                    conditionType: Ready
+                    conditionStatus: "True"
+  - step: detect-readiness
+    functionRef:
+      name: function-auto-ready
+  - step: sequence-creation
+    functionRef:
+      name: function-sequencer
+    input:
+      apiVersion: sequencer.fn.crossplane.io/v1beta1
+      kind: Input
+      enableDeletionSequencing: true
+      rules:
+        - sequence:
+          - first-resource
+          - second-resource
+        - sequence:
+          - second-resource
+          - optional-resource
+          condition: "observed.composite.resource.spec.enableOptional == true"

--- a/example/composition-delete-only.yaml
+++ b/example/composition-delete-only.yaml
@@ -1,0 +1,53 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: function-sequencer-delete-only
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+  - step: patch-and-transform
+    functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      resources:
+        - name: first-resource
+          base:
+            apiVersion: nop.crossplane.io/v1alpha1
+            kind: NopResource
+            spec:
+              forProvider:
+                conditionAfter:
+                  - time: 5s
+                    conditionType: Ready
+                    conditionStatus: "True"
+        - name: second-resource
+          base:
+            apiVersion: nop.crossplane.io/v1alpha1
+            kind: NopResource
+            spec:
+              forProvider:
+                conditionAfter:
+                  - time: 5s
+                    conditionType: Ready
+                    conditionStatus: "True"
+  - step: detect-readiness
+    functionRef:
+      name: function-auto-ready
+  - step: sequence-deletion-only
+    functionRef:
+      name: function-sequencer
+    input:
+      apiVersion: sequencer.fn.crossplane.io/v1beta1
+      kind: Input
+      enableDeletionSequencing: true
+      replayDeletion: true
+      rules:
+        - sequence:
+          - first-resource
+          - second-resource
+          deleteOnly: true

--- a/fn.go
+++ b/fn.go
@@ -145,6 +145,7 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 				f.log.Debug("Skipping sequence due to false condition", "condition", rule.Condition, "sequence", sequence)
 				response.Normal(rsp, fmt.Sprintf("Skipping sequence %v: condition %q evaluated to false", sequence, rule.Condition))
 				if in.EnableDeletionSequencing {
+					// Still generate Usages for already-observed resources so deletion order is preserved even when the sequence is skipped.
 					if err := f.generateObservedUsages(sequence, observedComposed, desiredComposed, usages, in.ReplayDeletion, in.UsageVersion); err != nil {
 						response.Fatal(rsp, errors.Wrap(err, "cannot generate usages for skipped sequence"))
 						return rsp, err

--- a/fn.go
+++ b/fn.go
@@ -135,6 +135,7 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 	for _, rule := range in.Rules {
 		sequence := rule.Sequence
 
+		// Evaluate the optional CEL condition to determine if this sequence should be processed.
 		skipSequence := false
 		if rule.Condition != "" {
 			conditionMet, err := f.evaluateCondition(req, rule.Condition)
@@ -149,7 +150,11 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 			}
 		}
 
-		// Generate Usages before checking skipSequence so deletion order is preserved even when the sequence is skipped.
+		// Generate Usages for all already-observed resource pairs in this sequence.
+		// This runs before checking skipSequence so that deletion order is preserved
+		// even when the sequence condition evaluates to false.
+		// Safe to run early: it only touches resources in observedComposed, while the
+		// creation-sequencing loop below only removes not-yet-observed resources from desiredComposed.
 		if in.EnableDeletionSequencing {
 			if err := f.generateObservedUsages(sequence, observedComposed, desiredComposed, usages, in.ReplayDeletion, in.UsageVersion); err != nil {
 				response.Fatal(rsp, errors.Wrap(err, "cannot generate usages for sequence"))
@@ -161,25 +166,30 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 			continue
 		}
 
+		// Creation sequencing: for each resource in the sequence (after the first),
+		// check that all predecessor resources exist and are ready before allowing creation.
 		for i, r := range sequence {
 			if i == 0 {
-				// We don't need to do anything for the first resource in the sequence.
 				continue
 			}
+			// Already exists in the cluster, no creation sequencing needed.
 			if _, created := observedComposed[r]; created {
 				f.log.Debug("Skipping already created resource", "r:", r)
 				continue
 			}
+			// DeleteOnly rules only generate usages (handled above), never block creation.
 			if rule.DeleteOnly {
 				f.log.Debug("Skipping resource creation due to deleteOnly rule", "r:", r)
 				continue
 			}
+			// Check each predecessor in the sequence to see if it exists and is ready.
 			for _, before := range sequence[:i] {
 				beforeRegex, err := getStrictRegex(string(before))
 				if err != nil {
 					response.Fatal(rsp, errors.Wrapf(err, "cannot compile regex %s", before))
 					return rsp, nil
 				}
+				// Collect all desired resources matching the predecessor pattern.
 				keys := []resource.Name{}
 				for k := range desiredComposed {
 					if beforeRegex.MatchString(string(k)) {
@@ -187,13 +197,11 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 					}
 				}
 
-				// We'll treat everything the same way adding all resources to the keys slice
-				// and then checking if they are ready.
+				// Count how many predecessor resources are ready.
 				desired := len(keys)
 				readyResources := 0
 				for _, k := range keys {
 					if d, ok := desiredComposed[k]; ok && d.Ready == resource.ReadyTrue {
-						// resource is ready, add it to the counter
 						readyResources++
 					}
 				}
@@ -204,11 +212,10 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 					return rsp, nil
 				}
 
+				// Predecessor not ready: delay creation by removing the current resource from desired.
 				if desired == 0 || desired != readyResources {
-					// no resource created
 					msg := fmt.Sprintf("Delaying creation of resource(s) matching %q because %q does not exist yet", r, before)
 					if desired > 0 {
-						// provide a nicer message if there are resources.
 						msg = fmt.Sprintf(
 							"Delaying creation of resource(s) matching %q because %q is not fully ready (%d of %d)",
 							r,
@@ -219,16 +226,15 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 					}
 					response.Normal(rsp, msg)
 					f.log.Debug(msg)
-					// find all objects that match the regex and delete them from the desiredComposed map
+					// Remove not-yet-observed resources matching r from desired to prevent premature creation.
 					for k := range desiredComposed {
 						if currentRegex.MatchString(string(k)) {
 							if _, ok := observedComposed[k]; ok {
-								// if the resource is already part of the observedComposed, we should not delete it
+								// Already exists in the cluster; keep it in desired.
 								continue
 							}
 							delete(desiredComposed, k)
 							if in.ResetCompositeReadiness {
-								// Reset the composite ready indicator to false when a desired resource is deleted.
 								rsp.Desired.Composite.Ready = v1.Ready_READY_FALSE
 							}
 						}
@@ -238,6 +244,7 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 			}
 		}
 	}
+	// Merge generated usages into desired resources before returning.
 	maps.Copy(desiredComposed, usages)
 	rsp.Desired.Resources = nil
 	return rsp, response.SetDesiredComposedResources(rsp, desiredComposed)

--- a/fn.go
+++ b/fn.go
@@ -135,6 +135,7 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 	for _, rule := range in.Rules {
 		sequence := rule.Sequence
 
+		skipSequence := false
 		if rule.Condition != "" {
 			conditionMet, err := f.evaluateCondition(req, rule.Condition)
 			if err != nil {
@@ -144,15 +145,20 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 			if !conditionMet {
 				f.log.Debug("Skipping sequence due to false condition", "condition", rule.Condition, "sequence", sequence)
 				response.Normal(rsp, fmt.Sprintf("Skipping sequence %v: condition %q evaluated to false", sequence, rule.Condition))
-				if in.EnableDeletionSequencing {
-					// Still generate Usages for already-observed resources so deletion order is preserved even when the sequence is skipped.
-					if err := f.generateObservedUsages(sequence, observedComposed, desiredComposed, usages, in.ReplayDeletion, in.UsageVersion); err != nil {
-						response.Fatal(rsp, errors.Wrap(err, "cannot generate usages for skipped sequence"))
-						return rsp, err
-					}
-				}
-				continue
+				skipSequence = true
 			}
+		}
+
+		// Generate Usages before checking skipSequence so deletion order is preserved even when the sequence is skipped.
+		if in.EnableDeletionSequencing {
+			if err := f.generateObservedUsages(sequence, observedComposed, desiredComposed, usages, in.ReplayDeletion, in.UsageVersion); err != nil {
+				response.Fatal(rsp, errors.Wrap(err, "cannot generate usages for sequence"))
+				return rsp, err
+			}
+		}
+
+		if skipSequence {
+			continue
 		}
 
 		for i, r := range sequence {
@@ -161,38 +167,14 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 				continue
 			}
 			if _, created := observedComposed[r]; created {
-				f.log.Debug("Processing ", "r:", r)
-				if in.EnableDeletionSequencing {
-					of := sequence[i-1]
-					ofRegex, err := getStrictRegex(string(of))
-					if err != nil {
-						response.Fatal(rsp, errors.Wrapf(err, "cannot compile regex %s", of))
-						return rsp, nil
-					}
-					for k := range desiredComposed {
-						if ofRegex.MatchString(string(k)) {
-							if _, ok := observedComposed[k]; ok {
-								f.log.Debug("Generate Usage", "of:", k, "by r:", r)
-								usage := GenerateUsage(&observedComposed[k].Resource.Unstructured, &observedComposed[r].Resource.Unstructured, in.ReplayDeletion, in.UsageVersion)
-								usageComposed := composed.New()
-								if err := convertViaJSON(usageComposed, usage); err != nil {
-									response.Fatal(rsp, errors.Wrapf(err, "cannot convert to JSON %s", usage))
-									return rsp, err
-								}
-								f.log.Debug("created usage", "kind", usageComposed.GetKind(), "name", usageComposed.GetName(), "namespace", usageComposed.GetNamespace())
-								usages[r+"-"+k+"-usage"] = &resource.DesiredComposed{Resource: usageComposed, Ready: resource.ReadyTrue}
-							}
-						}
-					}
-				}
-				// We've already created this resource, so we don't need to do anything.
-				// We only sequence creation of resources that don't exist yet.
+				f.log.Debug("Skipping already created resource", "r:", r)
 				continue
 			}
 			if rule.DeleteOnly {
+				f.log.Debug("Skipping resource creation due to deleteOnly rule", "r:", r)
 				continue
 			}
-			for b, before := range sequence[:i] {
+			for _, before := range sequence[:i] {
 				beforeRegex, err := getStrictRegex(string(before))
 				if err != nil {
 					response.Fatal(rsp, errors.Wrapf(err, "cannot compile regex %s", before))
@@ -253,29 +235,6 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 					}
 					break
 				}
-				// Only create Usages of the previous (i-1) resource in the sequence.
-				if b == i-1 && in.EnableDeletionSequencing {
-					for c, o := range observedComposed {
-						if currentRegex.MatchString(string(c)) && !isUsage(o, in.UsageVersion) {
-							for _, k := range keys {
-								obs, ok := observedComposed[k]
-								if !ok {
-									f.log.Debug("Skipping usage; before-resource not yet observed", "k:", k, "by c:", c)
-									continue
-								}
-								f.log.Debug("Generate Usage of ", "k:", k, "by c:", c)
-								usage := GenerateUsage(&obs.Resource.Unstructured, &o.Resource.Unstructured, in.ReplayDeletion, in.UsageVersion)
-								usageComposed := composed.New()
-								if err := convertViaJSON(usageComposed, usage); err != nil {
-									response.Fatal(rsp, errors.Wrapf(err, "cannot convert to JSON %s", usage))
-									return rsp, err
-								}
-								f.log.Debug("created usage", "kind", usageComposed.GetKind(), "name", usageComposed.GetName(), "namespace", usageComposed.GetNamespace())
-								usages[c+"-"+k+"-usage"] = &resource.DesiredComposed{Resource: usageComposed, Ready: resource.ReadyTrue}
-							}
-						}
-					}
-				}
 			}
 		}
 	}
@@ -285,7 +244,7 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 }
 
 // generateObservedUsages creates Usage/ClusterUsage resources for observed resources in a sequence,
-// protecting deletion order even when the sequence is skipped (e.g. condition evaluates to false).
+// ensuring deletion order is preserved.
 func (f *Function) generateObservedUsages(
 	sequence []resource.Name,
 	observedComposed map[resource.Name]resource.ObservedComposed,

--- a/fn.go
+++ b/fn.go
@@ -58,7 +58,7 @@ func (f *Function) evaluateCondition(req *v1.RunFunctionRequest, condition strin
 	if iss.Err() != nil {
 		return false, errors.Wrap(iss.Err(), "cannot type-check CEL condition")
 	}
-	if !checked.OutputType().IsExactType(cel.BoolType) {
+	if !checked.OutputType().IsExactType(cel.BoolType) && !checked.OutputType().IsExactType(cel.DynType) {
 		return false, errors.Errorf("CEL condition must return bool, got %s", checked.OutputType())
 	}
 	program, err := env.Program(checked)

--- a/fn.go
+++ b/fn.go
@@ -170,6 +170,7 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 		// check that all predecessor resources exist and are ready before allowing creation.
 		for i, r := range sequence {
 			if i == 0 {
+				// We don't need to do anything for the first resource in the sequence.
 				continue
 			}
 			// Already exists in the cluster, no creation sequencing needed.
@@ -197,11 +198,13 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 					}
 				}
 
-				// Count how many predecessor resources are ready.
+				// We'll treat everything the same way adding all resources to the keys slice
+				// and then checking if they are ready.
 				desired := len(keys)
 				readyResources := 0
 				for _, k := range keys {
 					if d, ok := desiredComposed[k]; ok && d.Ready == resource.ReadyTrue {
+						// resource is ready, add it to the counter
 						readyResources++
 					}
 				}
@@ -214,8 +217,10 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 
 				// Predecessor not ready: delay creation by removing the current resource from desired.
 				if desired == 0 || desired != readyResources {
+					// no resource created
 					msg := fmt.Sprintf("Delaying creation of resource(s) matching %q because %q does not exist yet", r, before)
 					if desired > 0 {
+						// provide a nicer message if there are resources.
 						msg = fmt.Sprintf(
 							"Delaying creation of resource(s) matching %q because %q is not fully ready (%d of %d)",
 							r,
@@ -226,11 +231,11 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 					}
 					response.Normal(rsp, msg)
 					f.log.Debug(msg)
-					// Remove not-yet-observed resources matching r from desired to prevent premature creation.
+					// find all objects that match the regex and delete them from the desiredComposed map
 					for k := range desiredComposed {
 						if currentRegex.MatchString(string(k)) {
 							if _, ok := observedComposed[k]; ok {
-								// Already exists in the cluster; keep it in desired.
+								// if the resource is already part of the observedComposed, we should not delete it
 								continue
 							}
 							delete(desiredComposed, k)

--- a/fn.go
+++ b/fn.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
@@ -14,7 +15,9 @@ import (
 	apiextensionsv1beta1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1beta1"
 	protectionv1beta1 "github.com/crossplane/crossplane/apis/v2/protection/v1beta1"
 	"github.com/crossplane/function-sequencer/input/v1beta1"
+	"github.com/google/cel-go/cel"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/structpb"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	v1 "github.com/crossplane/function-sdk-go/proto/v1"
@@ -29,6 +32,52 @@ type Function struct {
 	v1.UnimplementedFunctionRunnerServiceServer
 
 	log logging.Logger
+}
+
+// celEnv lazily initializes the shared CEL environment on first use.
+var celEnv = sync.OnceValues(func() (*cel.Env, error) {
+	return cel.NewEnv(
+		cel.Types(&v1.State{}, &structpb.Struct{}),
+		cel.Variable("observed", cel.ObjectType("apiextensions.fn.proto.v1.State")),
+		cel.Variable("desired", cel.ObjectType("apiextensions.fn.proto.v1.State")),
+		cel.Variable("context", cel.ObjectType("google.protobuf.Struct")),
+	)
+})
+
+// evaluateCondition evaluates a CEL expression against the function request.
+func (f *Function) evaluateCondition(req *v1.RunFunctionRequest, condition string) (bool, error) {
+	env, err := celEnv()
+	if err != nil {
+		return false, errors.Wrap(err, "cannot create CEL environment")
+	}
+	ast, iss := env.Parse(condition)
+	if iss.Err() != nil {
+		return false, errors.Wrap(iss.Err(), "cannot parse CEL condition")
+	}
+	checked, iss := env.Check(ast)
+	if iss.Err() != nil {
+		return false, errors.Wrap(iss.Err(), "cannot type-check CEL condition")
+	}
+	if !checked.OutputType().IsExactType(cel.BoolType) {
+		return false, errors.Errorf("CEL condition must return bool, got %s", checked.OutputType())
+	}
+	program, err := env.Program(checked)
+	if err != nil {
+		return false, errors.Wrap(err, "cannot compile CEL condition")
+	}
+	result, _, err := program.Eval(map[string]any{
+		"observed": req.GetObserved(),
+		"desired":  req.GetDesired(),
+		"context":  req.GetContext(),
+	})
+	if err != nil {
+		return false, errors.Wrap(err, "cannot evaluate CEL condition")
+	}
+	ret, ok := result.Value().(bool)
+	if !ok {
+		return false, errors.New("CEL condition result is not bool")
+	}
+	return ret, nil
 }
 
 const (
@@ -81,13 +130,30 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 		return rsp, nil
 	}
 
-	sequences := make([][]resource.Name, 0, len(in.Rules))
-	for _, rule := range in.Rules {
-		sequences = append(sequences, rule.Sequence)
-	}
 	usages := make(map[resource.Name]*resource.DesiredComposed)
 
-	for _, sequence := range sequences {
+	for _, rule := range in.Rules {
+		sequence := rule.Sequence
+
+		if rule.Condition != "" {
+			conditionMet, err := f.evaluateCondition(req, rule.Condition)
+			if err != nil {
+				response.Fatal(rsp, errors.Wrapf(err, "cannot evaluate condition %q for sequence %v", rule.Condition, sequence))
+				return rsp, nil
+			}
+			if !conditionMet {
+				f.log.Debug("Skipping sequence due to false condition", "condition", rule.Condition, "sequence", sequence)
+				response.Normal(rsp, fmt.Sprintf("Skipping sequence %v: condition %q evaluated to false", sequence, rule.Condition))
+				if in.EnableDeletionSequencing {
+					if err := f.generateObservedUsages(sequence, observedComposed, desiredComposed, usages, in.ReplayDeletion, in.UsageVersion); err != nil {
+						response.Fatal(rsp, errors.Wrap(err, "cannot generate usages for skipped sequence"))
+						return rsp, err
+					}
+				}
+				continue
+			}
+		}
+
 		for i, r := range sequence {
 			if i == 0 {
 				// We don't need to do anything for the first resource in the sequence.
@@ -120,6 +186,9 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 				}
 				// We've already created this resource, so we don't need to do anything.
 				// We only sequence creation of resources that don't exist yet.
+				continue
+			}
+			if rule.DeleteOnly {
 				continue
 			}
 			for b, before := range sequence[:i] {
@@ -212,6 +281,48 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 	maps.Copy(desiredComposed, usages)
 	rsp.Desired.Resources = nil
 	return rsp, response.SetDesiredComposedResources(rsp, desiredComposed)
+}
+
+// generateObservedUsages creates Usage/ClusterUsage resources for observed resources in a sequence,
+// protecting deletion order even when the sequence is skipped (e.g. condition evaluates to false).
+func (f *Function) generateObservedUsages(
+	sequence []resource.Name,
+	observedComposed map[resource.Name]resource.ObservedComposed,
+	desiredComposed map[resource.Name]*resource.DesiredComposed,
+	usages map[resource.Name]*resource.DesiredComposed,
+	replayDeletion bool,
+	usageVersion v1beta1.UsageVersion,
+) error {
+	for i := 1; i < len(sequence); i++ {
+		rRegex, err := getStrictRegex(string(sequence[i]))
+		if err != nil {
+			return errors.Wrapf(err, "cannot compile regex %s", sequence[i])
+		}
+		ofRegex, err := getStrictRegex(string(sequence[i-1]))
+		if err != nil {
+			return errors.Wrapf(err, "cannot compile regex %s", sequence[i-1])
+		}
+		for c, o := range observedComposed {
+			if !rRegex.MatchString(string(c)) || isUsage(o, usageVersion) {
+				continue
+			}
+			for k := range desiredComposed {
+				if !ofRegex.MatchString(string(k)) {
+					continue
+				}
+				if obs, ok := observedComposed[k]; ok {
+					f.log.Debug("Generate Usage for observed resource", "of:", k, "by:", c)
+					usage := GenerateUsage(&obs.Resource.Unstructured, &o.Resource.Unstructured, replayDeletion, usageVersion)
+					usageComposed := composed.New()
+					if err := convertViaJSON(usageComposed, usage); err != nil {
+						return errors.Wrapf(err, "cannot convert to JSON %s", usage)
+					}
+					usages[c+"-"+k+"-usage"] = &resource.DesiredComposed{Resource: usageComposed, Ready: resource.ReadyTrue}
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func getStrictRegex(pattern string) (*regexp.Regexp, error) {

--- a/fn.go
+++ b/fn.go
@@ -34,8 +34,8 @@ type Function struct {
 	log logging.Logger
 }
 
-// celEnv lazily initializes the shared CEL environment on first use.
-var celEnv = sync.OnceValues(func() (*cel.Env, error) {
+// getCELEnv lazily initializes the shared CEL environment on first use.
+var getCELEnv = sync.OnceValues(func() (*cel.Env, error) { //nolint:gochecknoglobals // lazy singleton
 	return cel.NewEnv(
 		cel.Types(&v1.State{}, &structpb.Struct{}),
 		cel.Variable("observed", cel.ObjectType("apiextensions.fn.proto.v1.State")),
@@ -46,7 +46,7 @@ var celEnv = sync.OnceValues(func() (*cel.Env, error) {
 
 // evaluateCondition evaluates a CEL expression against the function request.
 func (f *Function) evaluateCondition(req *v1.RunFunctionRequest, condition string) (bool, error) {
-	env, err := celEnv()
+	env, err := getCELEnv()
 	if err != nil {
 		return false, errors.Wrap(err, "cannot create CEL environment")
 	}

--- a/fn_test.go
+++ b/fn_test.go
@@ -1927,6 +1927,532 @@ func TestRunFunction(t *testing.T) {
 				},
 			},
 		},
+		"ConditionTrueRunsNormally": {
+			reason: "When condition evaluates to true, normal sequencing should apply — second blocked because first not ready",
+			args: args{
+				req: &v1.RunFunctionRequest{
+					Input: resource.MustStructObject(&v1beta1.Input{
+						Rules: []v1beta1.SequencingRule{
+							{
+								Sequence: []resource.Name{
+									"first",
+									"second",
+								},
+								Condition: `observed.composite.resource.spec.count == 2.0`,
+							},
+						},
+					}),
+					Observed: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(mr),
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &v1.RunFunctionResponse{
+					Meta: &v1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*v1.Result{
+						{
+							Severity: v1.Severity_SEVERITY_NORMAL,
+							Message:  `Delaying creation of resource(s) matching "second" because "first" is not fully ready (0 of 1)`,
+							Target:   &target,
+						},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(mr),
+							},
+						},
+					},
+				},
+			},
+		},
+		"ConditionFalseSkipsSequence": {
+			reason: "When condition evaluates to false, sequence should be skipped — second stays in desired and composite readiness is not reset even with resetCompositeReadiness=true",
+			args: args{
+				req: &v1.RunFunctionRequest{
+					Input: resource.MustStructObject(&v1beta1.Input{
+						ResetCompositeReadiness: true,
+						Rules: []v1beta1.SequencingRule{
+							{
+								Sequence: []resource.Name{
+									"first",
+									"second",
+								},
+								Condition: `observed.composite.resource.spec.count == 999.0`,
+							},
+						},
+					}),
+					Observed: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(mr),
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &v1.RunFunctionResponse{
+					Meta: &v1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*v1.Result{
+						{
+							Severity: v1.Severity_SEVERITY_NORMAL,
+							Message:  `Skipping sequence [first second]: condition "observed.composite.resource.spec.count == 999.0" evaluated to false`,
+							Target:   &target,
+						},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(mr),
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+							},
+						},
+					},
+				},
+			},
+		},
+		"ConditionEmptyPassesThrough": {
+			reason: "Empty condition string should behave identically to no condition — normal sequencing",
+			args: args{
+				req: &v1.RunFunctionRequest{
+					Input: resource.MustStructObject(&v1beta1.Input{
+						Rules: []v1beta1.SequencingRule{
+							{
+								Sequence: []resource.Name{
+									"first",
+									"second",
+								},
+								Condition: "",
+							},
+						},
+					}),
+					Observed: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(mr),
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &v1.RunFunctionResponse{
+					Meta: &v1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*v1.Result{
+						{
+							Severity: v1.Severity_SEVERITY_NORMAL,
+							Message:  `Delaying creation of resource(s) matching "second" because "first" is not fully ready (0 of 1)`,
+							Target:   &target,
+						},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(mr),
+							},
+						},
+					},
+				},
+			},
+		},
+		"ConditionFalseProtectsObservedUsages": {
+			reason: "When condition is false but resources are observed and deletion sequencing is enabled, Usages must still be generated",
+			args: args{
+				req: &v1.RunFunctionRequest{
+					Input: resource.MustStructObject(&v1beta1.Input{
+						EnableDeletionSequencing: true,
+						ReplayDeletion:           true,
+						Rules: []v1beta1.SequencingRule{
+							{
+								Sequence: []resource.Name{
+									"first",
+									"second",
+								},
+								Condition: `observed.composite.resource.spec.count == 999.0`,
+							},
+						},
+					}),
+					Observed: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(xr),
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+							},
+						},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(xr),
+								Ready:    v1.Ready_READY_TRUE,
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+								Ready:    v1.Ready_READY_TRUE,
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &v1.RunFunctionResponse{
+					Meta: &v1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*v1.Result{
+						{
+							Severity: v1.Severity_SEVERITY_NORMAL,
+							Message:  `Skipping sequence [first second]: condition "observed.composite.resource.spec.count == 999.0" evaluated to false`,
+							Target:   &target,
+						},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(xr),
+								Ready:    v1.Ready_READY_TRUE,
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+								Ready:    v1.Ready_READY_TRUE,
+							},
+							"second-first-usage": {
+								Resource: resource.MustStructJSON(uv2),
+								Ready:    v1.Ready_READY_TRUE,
+							},
+						},
+					},
+				},
+			},
+		},
+		"ConditionFalseNoObservedNoUsages": {
+			reason: "When condition is false and no resources are observed, no Usages should be generated",
+			args: args{
+				req: &v1.RunFunctionRequest{
+					Input: resource.MustStructObject(&v1beta1.Input{
+						EnableDeletionSequencing: true,
+						ReplayDeletion:           true,
+						Rules: []v1beta1.SequencingRule{
+							{
+								Sequence: []resource.Name{
+									"first",
+									"second",
+								},
+								Condition: `observed.composite.resource.spec.count == 999.0`,
+							},
+						},
+					}),
+					Observed: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(mr),
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &v1.RunFunctionResponse{
+					Meta: &v1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*v1.Result{
+						{
+							Severity: v1.Severity_SEVERITY_NORMAL,
+							Message:  `Skipping sequence [first second]: condition "observed.composite.resource.spec.count == 999.0" evaluated to false`,
+							Target:   &target,
+						},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(mr),
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+							},
+						},
+					},
+				},
+			},
+		},
+		"ConditionFalseNoDeletionSequencing": {
+			reason: "When condition is false and enableDeletionSequencing is false, no Usages even with observed resources",
+			args: args{
+				req: &v1.RunFunctionRequest{
+					Input: resource.MustStructObject(&v1beta1.Input{
+						EnableDeletionSequencing: false,
+						Rules: []v1beta1.SequencingRule{
+							{
+								Sequence: []resource.Name{
+									"first",
+									"second",
+								},
+								Condition: `observed.composite.resource.spec.count == 999.0`,
+							},
+						},
+					}),
+					Observed: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(xr),
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+							},
+						},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(xr),
+								Ready:    v1.Ready_READY_TRUE,
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+								Ready:    v1.Ready_READY_TRUE,
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &v1.RunFunctionResponse{
+					Meta: &v1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*v1.Result{
+						{
+							Severity: v1.Severity_SEVERITY_NORMAL,
+							Message:  `Skipping sequence [first second]: condition "observed.composite.resource.spec.count == 999.0" evaluated to false`,
+							Target:   &target,
+						},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(xr),
+								Ready:    v1.Ready_READY_TRUE,
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+								Ready:    v1.Ready_READY_TRUE,
+							},
+						},
+					},
+				},
+			},
+		},
+		"DeleteOnlySkipsCreationBlockingNoUsagesNoReadinessReset": {
+			reason: "With deleteOnly=true and no deletion sequencing: resources are not blocked even when predecessors are not ready, no Usages are generated, and composite readiness is not reset even with resetCompositeReadiness=true",
+			args: args{
+				req: &v1.RunFunctionRequest{
+					Input: resource.MustStructObject(&v1beta1.Input{
+						ResetCompositeReadiness: true,
+						Rules: []v1beta1.SequencingRule{
+							{
+								Sequence: []resource.Name{
+									"first",
+									"second",
+								},
+								DeleteOnly: true,
+							},
+						},
+					}),
+					Observed: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(mr),
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &v1.RunFunctionResponse{
+					Meta: &v1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(mr),
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+							},
+						},
+					},
+				},
+			},
+		},
+		"DeleteOnlyGeneratesUsages": {
+			reason: "With deleteOnly=true and enableDeletionSequencing=true, Usage resources should still be created for observed resources",
+			args: args{
+				req: &v1.RunFunctionRequest{
+					Input: resource.MustStructObject(&v1beta1.Input{
+						EnableDeletionSequencing: true,
+						ReplayDeletion:           true,
+						Rules: []v1beta1.SequencingRule{
+							{
+								Sequence: []resource.Name{
+									"first",
+									"second",
+								},
+								DeleteOnly: true,
+							},
+						},
+					}),
+					Observed: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(xr),
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+							},
+						},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(xr),
+								Ready:    v1.Ready_READY_TRUE,
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+								Ready:    v1.Ready_READY_TRUE,
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &v1.RunFunctionResponse{
+					Meta: &v1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(xr),
+								Ready:    v1.Ready_READY_TRUE,
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+								Ready:    v1.Ready_READY_TRUE,
+							},
+							"second-first-usage": {
+								Resource: resource.MustStructJSON(uv2),
+								Ready:    v1.Ready_READY_TRUE,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range cases {
@@ -2038,6 +2564,62 @@ func TestRunFunctionCacheTTL(t *testing.T) {
 			}
 			if diff := cmp.Diff(nil, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s\nf.RunFunction(...): -want err, +got err:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestRunFunctionConditionErrors(t *testing.T) {
+	xr := `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"count":2}}`
+	mr := `{"apiVersion":"example.org/v1","kind":"MR","metadata":{"name":"cool-mr"}}`
+
+	cases := map[string]struct {
+		reason    string
+		condition string
+	}{
+		"InvalidExpression": {
+			reason:    "Invalid CEL syntax should produce Fatal",
+			condition: `invalid $$$ expression`,
+		},
+		"NonBoolResult": {
+			reason:    "CEL expression returning non-bool should produce Fatal",
+			condition: `observed.composite.resource.spec.count`,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			f := &Function{log: logging.NewNopLogger()}
+			req := &v1.RunFunctionRequest{
+				Input: resource.MustStructObject(&v1beta1.Input{
+					Rules: []v1beta1.SequencingRule{
+						{
+							Sequence:  []resource.Name{"first", "second"},
+							Condition: tc.condition,
+						},
+					},
+				}),
+				Observed: &v1.State{
+					Composite: &v1.Resource{Resource: resource.MustStructJSON(xr)},
+					Resources: map[string]*v1.Resource{},
+				},
+				Desired: &v1.State{
+					Composite: &v1.Resource{Resource: resource.MustStructJSON(xr)},
+					Resources: map[string]*v1.Resource{
+						"first":  {Resource: resource.MustStructJSON(mr)},
+						"second": {Resource: resource.MustStructJSON(mr)},
+					},
+				},
+			}
+			rsp, err := f.RunFunction(context.Background(), req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(rsp.Results) == 0 {
+				t.Fatal("expected at least one result")
+			}
+			if rsp.Results[0].Severity != v1.Severity_SEVERITY_FATAL {
+				t.Errorf("%s: expected FATAL severity, got %s", tc.reason, rsp.Results[0].Severity)
 			}
 		})
 	}

--- a/fn_test.go
+++ b/fn_test.go
@@ -2615,11 +2615,11 @@ func TestRunFunctionConditionErrors(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if len(rsp.Results) == 0 {
+			if len(rsp.GetResults()) == 0 {
 				t.Fatal("expected at least one result")
 			}
-			if rsp.Results[0].Severity != v1.Severity_SEVERITY_FATAL {
-				t.Errorf("%s: expected FATAL severity, got %s", tc.reason, rsp.Results[0].Severity)
+			if rsp.GetResults()[0].GetSeverity() != v1.Severity_SEVERITY_FATAL {
+				t.Errorf("%s: expected FATAL severity, got %s", tc.reason, rsp.GetResults()[0].GetSeverity())
 			}
 		})
 	}

--- a/fn_test.go
+++ b/fn_test.go
@@ -1986,6 +1986,127 @@ func TestRunFunction(t *testing.T) {
 				},
 			},
 		},
+		"ConditionDynBoolTrueRunsNormally": {
+			reason: "When condition navigates into Struct fields (dyn type) and evaluates to true, normal sequencing should apply",
+			args: args{
+				req: &v1.RunFunctionRequest{
+					Input: resource.MustStructObject(&v1beta1.Input{
+						Rules: []v1beta1.SequencingRule{
+							{
+								Sequence: []resource.Name{
+									"first",
+									"second",
+								},
+								Condition: `observed.composite.resource.spec.parameters.multiAZ == true`,
+							},
+						},
+					}),
+					Observed: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"parameters":{"multiAZ":true}}}`),
+						},
+						Resources: map[string]*v1.Resource{},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"parameters":{"multiAZ":true}}}`),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(mr),
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &v1.RunFunctionResponse{
+					Meta: &v1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*v1.Result{
+						{
+							Severity: v1.Severity_SEVERITY_NORMAL,
+							Message:  `Delaying creation of resource(s) matching "second" because "first" is not fully ready (0 of 1)`,
+							Target:   &target,
+						},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"parameters":{"multiAZ":true}}}`),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(mr),
+							},
+						},
+					},
+				},
+			},
+		},
+		"ConditionDynBoolFalseSkipsSequence": {
+			reason: "When condition navigates into Struct fields (dyn type) and evaluates to false, sequence should be skipped",
+			args: args{
+				req: &v1.RunFunctionRequest{
+					Input: resource.MustStructObject(&v1beta1.Input{
+						Rules: []v1beta1.SequencingRule{
+							{
+								Sequence: []resource.Name{
+									"first",
+									"second",
+								},
+								Condition: `observed.composite.resource.spec.parameters.multiAZ == true`,
+							},
+						},
+					}),
+					Observed: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"parameters":{"multiAZ":false}}}`),
+						},
+						Resources: map[string]*v1.Resource{},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"parameters":{"multiAZ":false}}}`),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(mr),
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &v1.RunFunctionResponse{
+					Meta: &v1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*v1.Result{
+						{
+							Severity: v1.Severity_SEVERITY_NORMAL,
+							Message:  `Skipping sequence [first second]: condition "observed.composite.resource.spec.parameters.multiAZ == true" evaluated to false`,
+							Target:   &target,
+						},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{
+							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"parameters":{"multiAZ":false}}}`),
+						},
+						Resources: map[string]*v1.Resource{
+							"first": {
+								Resource: resource.MustStructJSON(mr),
+							},
+							"second": {
+								Resource: resource.MustStructJSON(mr),
+							},
+						},
+					},
+				},
+			},
+		},
 		"ConditionFalseSkipsSequence": {
 			reason: "When condition evaluates to false, sequence should be skipped — second stays in desired and composite readiness is not reset even with resetCompositeReadiness=true",
 			args: args{

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/crossplane/crossplane-runtime/v2 v2.3.3
 	github.com/crossplane/crossplane/apis/v2 v2.3.3
 	github.com/crossplane/function-sdk-go v0.7.1
+	github.com/google/cel-go v0.28.1
 	github.com/google/go-cmp v0.7.0
 	google.golang.org/protobuf v1.36.11
 	k8s.io/apimachinery v0.35.4
@@ -14,7 +15,9 @@ require (
 )
 
 require (
+	cel.dev/expr v0.25.1 // indirect
 	dario.cat/mergo v1.0.2 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -66,6 +69,7 @@ require (
 	go.uber.org/zap v1.28.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
@@ -75,6 +79,7 @@ require (
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260427160629-7cedc36a6bc4 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4 // indirect
 	google.golang.org/grpc v1.81.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
-github.com/google/cel-go v0.28.0 h1:KjSWstCpz/MN5t4a8gnGJNIYUsJRpdi/r97xWDphIQc=
-github.com/google/cel-go v0.28.0/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
+github.com/google/cel-go v0.28.1 h1:YWIwi77J4xIsYUwAF/iIuS6haffzIHS8yWI8glSbLWM=
+github.com/google/cel-go v0.28.1/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
 github.com/google/gnostic-models v0.7.1 h1:SisTfuFKJSKM5CPZkffwi6coztzzeYUhc3v4yxLWH8c=
 github.com/google/gnostic-models v0.7.1/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/input/v1beta1/input.go
+++ b/input/v1beta1/input.go
@@ -18,6 +18,18 @@ type SequencingRule struct {
 	// TODO: Should we add a way to infer sequencing from usages? e.g. InferFromUsages: true
 	// InferFromUsages bool            `json:"inferFromUsages,omitempty"`
 
+	// Condition is a CEL expression evaluated against the function request state.
+	// When set and evaluates to false, the entire sequence is skipped for creation
+	// sequencing. Available variables: observed, desired, context (matching function-cel-filter conventions).
+	// Example: observed.composite.resource.spec.enableFeatureX == true
+	// +optional
+	Condition string `json:"condition,omitempty"`
+
+	// DeleteOnly skips creation sequencing for this rule.
+	// Resources are not blocked from creation; only deletion ordering (via Usage/ClusterUsage) is enforced when enableDeletionSequencing is true.
+	// +optional
+	DeleteOnly bool `json:"deleteOnly,omitempty"`
+
 	// Sequence is a list of composition resource names.
 	Sequence []resource.Name `json:"sequence,omitempty"`
 }

--- a/package/input/sequencer.fn.crossplane.io_inputs.yaml
+++ b/package/input/sequencer.fn.crossplane.io_inputs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: inputs.sequencer.fn.crossplane.io
 spec:
   group: sequencer.fn.crossplane.io
@@ -29,6 +29,7 @@ spec:
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           cacheTTL:
+            default: 1m
             description: |-
               CacheTTL sets the time-to-live for the Function response.
               Function response caching is an alpha feature in Crossplane and can
@@ -62,6 +63,20 @@ spec:
             items:
               description: SequencingRule is a rule that describes a sequence of resources.
               properties:
+                condition:
+                  description: |-
+                    Condition is a CEL expression evaluated against the function request state.
+                    When set and evaluates to false, the entire sequence is skipped for creation
+                    sequencing. Available variables: observed, desired, context (matching
+                    function-cel-filter conventions).
+                    Example: observed.composite.resource.spec.enableFeatureX == true
+                  type: string
+                deleteOnly:
+                  description: |-
+                    DeleteOnly skips creation sequencing for this rule.
+                    Resources are not blocked from creation; only deletion ordering
+                    (via Usage/ClusterUsage) is enforced when enableDeletionSequencing is true.
+                  type: boolean
                 sequence:
                   description: Sequence is a list of composition resource names.
                   items:

--- a/package/input/sequencer.fn.crossplane.io_inputs.yaml
+++ b/package/input/sequencer.fn.crossplane.io_inputs.yaml
@@ -67,15 +67,13 @@ spec:
                   description: |-
                     Condition is a CEL expression evaluated against the function request state.
                     When set and evaluates to false, the entire sequence is skipped for creation
-                    sequencing. Available variables: observed, desired, context (matching
-                    function-cel-filter conventions).
+                    sequencing. Available variables: observed, desired, context (matching function-cel-filter conventions).
                     Example: observed.composite.resource.spec.enableFeatureX == true
                   type: string
                 deleteOnly:
                   description: |-
                     DeleteOnly skips creation sequencing for this rule.
-                    Resources are not blocked from creation; only deletion ordering
-                    (via Usage/ClusterUsage) is enforced when enableDeletionSequencing is true.
+                    Resources are not blocked from creation; only deletion ordering (via Usage/ClusterUsage) is enforced when enableDeletionSequencing is true.
                   type: boolean
                 sequence:
                   description: Sequence is a list of composition resource names.


### PR DESCRIPTION
### Description of your changes

Fixes #69 

It adds a CEL condition field for each rule, so we can opt-in to enable/disable that rule.
In order to avoid flaky conditions, once a condition is met and a Usage gets created, we'll keep that even if the condition flips.

Also adds a _deletion only_ mode, for rules where we want to ensure deletion ordering but don't care that much about create (we rely on eventual consistency).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
