### PR TITLE
feat: support createOnly mode for rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The `deleteOnly` flag is per-rule, so you can mix creation-sequenced and delete-
 ## Create-Only Mode
 
 The inverse of `deleteOnly`. When `createOnly` is set to `true` on a rule, creation sequencing is enforced as normal,
-but no `Usage`/`ClusterUsage` resources are generated for that rule — even when `enableDeletionSequencing` is enabled.
+but no `Usage`/`ClusterUsage` resources are generated for that rule, even when `enableDeletionSequencing` is enabled.
 
 This is useful when you need strict creation ordering but don't care about deletion ordering for a particular sequence.
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,34 @@ The `deleteOnly` flag is per-rule, so you can mix creation-sequenced and delete-
           deleteOnly: true
 ```
 
+## Create-Only Mode
+
+The inverse of `deleteOnly`. When `createOnly` is set to `true` on a rule, creation sequencing is enforced as normal,
+but no `Usage`/`ClusterUsage` resources are generated for that rule — even when `enableDeletionSequencing` is enabled.
+
+This is useful when you need strict creation ordering but don't care about deletion ordering for a particular sequence.
+
+```yaml
+  - step: sequence-creation-only
+    functionRef:
+      name: function-sequencer
+    input:
+      apiVersion: sequencer.fn.crossplane.io/v1beta1
+      kind: Input
+      enableDeletionSequencing: true
+      rules:
+        - sequence:
+          - vpc
+          - subnet
+          - security-group
+          createOnly: true
+```
+
+In the example above, `subnet` waits for `vpc` and `security-group` waits for `subnet` before being created.
+On deletion, resources are deleted without ordering constraints.
+
+> **Note:** `createOnly` and `deleteOnly` are mutually exclusive on the same rule, setting both options ends up in error.
+
 ## Conditional Sequences
 
 Rules can include a `condition` field containing a [CEL](https://github.com/google/cel-spec) (Common Expression Language) expression.

--- a/fn.go
+++ b/fn.go
@@ -135,6 +135,11 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 	for _, rule := range in.Rules {
 		sequence := rule.Sequence
 
+		if rule.DeleteOnly && rule.CreateOnly {
+			response.Fatal(rsp, errors.Errorf("rule for sequence %v cannot have both deleteOnly and createOnly set to true", sequence))
+			return rsp, nil
+		}
+
 		// Evaluate the optional CEL condition to determine if this sequence should be processed.
 		skipSequence := false
 		if rule.Condition != "" {
@@ -155,7 +160,8 @@ func (f *Function) RunFunction(_ context.Context, req *v1.RunFunctionRequest) (*
 		// even when the sequence condition evaluates to false.
 		// Safe to run early: it only touches resources in observedComposed, while the
 		// creation-sequencing loop below only removes not-yet-observed resources from desiredComposed.
-		if in.EnableDeletionSequencing {
+		// CreateOnly rules skip usage generation entirely (they only enforce creation ordering).
+		if in.EnableDeletionSequencing && !rule.CreateOnly {
 			if err := f.generateObservedUsages(sequence, observedComposed, desiredComposed, usages, in.ReplayDeletion, in.UsageVersion); err != nil {
 				response.Fatal(rsp, errors.Wrap(err, "cannot generate usages for sequence"))
 				return rsp, err

--- a/fn_test.go
+++ b/fn_test.go
@@ -2519,14 +2519,14 @@ func TestRunFunction(t *testing.T) {
 					Observed: &v1.State{
 						Composite: &v1.Resource{Resource: resource.MustStructJSON(xr)},
 						Resources: map[string]*v1.Resource{
-							"first": {Resource: resource.MustStructJSON(xr)},
+							"first":  {Resource: resource.MustStructJSON(xr)},
 							"second": {Resource: resource.MustStructJSON(mr)},
 						},
 					},
 					Desired: &v1.State{
 						Composite: &v1.Resource{Resource: resource.MustStructJSON(xr)},
 						Resources: map[string]*v1.Resource{
-							"first": {Resource: resource.MustStructJSON(xr), Ready: v1.Ready_READY_TRUE},
+							"first":  {Resource: resource.MustStructJSON(xr), Ready: v1.Ready_READY_TRUE},
 							"second": {Resource: resource.MustStructJSON(mr), Ready: v1.Ready_READY_TRUE},
 						},
 					},
@@ -2538,7 +2538,7 @@ func TestRunFunction(t *testing.T) {
 					Desired: &v1.State{
 						Composite: &v1.Resource{Resource: resource.MustStructJSON(xr)},
 						Resources: map[string]*v1.Resource{
-							"first": {Resource: resource.MustStructJSON(xr), Ready: v1.Ready_READY_TRUE},
+							"first":  {Resource: resource.MustStructJSON(xr), Ready: v1.Ready_READY_TRUE},
 							"second": {Resource: resource.MustStructJSON(mr), Ready: v1.Ready_READY_TRUE},
 						},
 					},

--- a/fn_test.go
+++ b/fn_test.go
@@ -2502,6 +2502,95 @@ func TestRunFunction(t *testing.T) {
 				},
 			},
 		},
+		"CreateOnlyBlocksCreationButSkipsUsages": {
+			reason: "createOnly=true still blocks creation when predecessors not ready, but generates no Usages even with enableDeletionSequencing=true",
+			args: args{
+				req: &v1.RunFunctionRequest{
+					Input: resource.MustStructObject(&v1beta1.Input{
+						EnableDeletionSequencing: true,
+						ReplayDeletion:           true,
+						Rules: []v1beta1.SequencingRule{
+							{
+								Sequence:   []resource.Name{"first", "second"},
+								CreateOnly: true,
+							},
+						},
+					}),
+					Observed: &v1.State{
+						Composite: &v1.Resource{Resource: resource.MustStructJSON(xr)},
+						Resources: map[string]*v1.Resource{
+							"first": {Resource: resource.MustStructJSON(xr)},
+							"second": {Resource: resource.MustStructJSON(mr)},
+						},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{Resource: resource.MustStructJSON(xr)},
+						Resources: map[string]*v1.Resource{
+							"first": {Resource: resource.MustStructJSON(xr), Ready: v1.Ready_READY_TRUE},
+							"second": {Resource: resource.MustStructJSON(mr), Ready: v1.Ready_READY_TRUE},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &v1.RunFunctionResponse{
+					Meta: &v1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
+					Desired: &v1.State{
+						Composite: &v1.Resource{Resource: resource.MustStructJSON(xr)},
+						Resources: map[string]*v1.Resource{
+							"first": {Resource: resource.MustStructJSON(xr), Ready: v1.Ready_READY_TRUE},
+							"second": {Resource: resource.MustStructJSON(mr), Ready: v1.Ready_READY_TRUE},
+						},
+					},
+				},
+			},
+		},
+		"CreateOnlyAndDeleteOnlyMutuallyExclusive": {
+			reason: "Both createOnly and deleteOnly set returns fatal error",
+			args: args{
+				req: &v1.RunFunctionRequest{
+					Input: resource.MustStructObject(&v1beta1.Input{
+						Rules: []v1beta1.SequencingRule{
+							{
+								Sequence:   []resource.Name{"first", "second"},
+								CreateOnly: true,
+								DeleteOnly: true,
+							},
+						},
+					}),
+					Observed: &v1.State{
+						Composite: &v1.Resource{Resource: resource.MustStructJSON(xr)},
+						Resources: map[string]*v1.Resource{},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{Resource: resource.MustStructJSON(xr)},
+						Resources: map[string]*v1.Resource{
+							"first":  {Resource: resource.MustStructJSON(mr)},
+							"second": {Resource: resource.MustStructJSON(mr)},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &v1.RunFunctionResponse{
+					Meta: &v1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*v1.Result{
+						{
+							Severity: v1.Severity_SEVERITY_FATAL,
+							Message:  `rule for sequence [first second] cannot have both deleteOnly and createOnly set to true`,
+							Target:   &target,
+						},
+					},
+					Desired: &v1.State{
+						Composite: &v1.Resource{Resource: resource.MustStructJSON(xr)},
+						Resources: map[string]*v1.Resource{
+							"first":  {Resource: resource.MustStructJSON(mr)},
+							"second": {Resource: resource.MustStructJSON(mr)},
+						},
+					},
+				},
+			},
+		},
 		"DeleteOnlyGeneratesUsages": {
 			reason: "With deleteOnly=true and enableDeletionSequencing=true, Usage resources should still be created for observed resources",
 			args: args{

--- a/input/v1beta1/input.go
+++ b/input/v1beta1/input.go
@@ -14,6 +14,7 @@ import (
 // It is a KRM-like object, so we generate a CRD to describe its schema.
 
 // SequencingRule is a rule that describes a sequence of resources.
+// +kubebuilder:validation:XValidation:rule="!(self.createOnly && self.deleteOnly)",message="createOnly and deleteOnly are mutually exclusive"
 type SequencingRule struct {
 	// TODO: Should we add a way to infer sequencing from usages? e.g. InferFromUsages: true
 	// InferFromUsages bool            `json:"inferFromUsages,omitempty"`
@@ -25,8 +26,15 @@ type SequencingRule struct {
 	// +optional
 	Condition string `json:"condition,omitempty"`
 
+	// CreateOnly skips deletion sequencing for this rule.
+	// Creation ordering is still enforced, but no Usage/ClusterUsage resources are generated even when enableDeletionSequencing is true.
+	// Mutually exclusive with DeleteOnly.
+	// +optional
+	CreateOnly bool `json:"createOnly,omitempty"`
+
 	// DeleteOnly skips creation sequencing for this rule.
 	// Resources are not blocked from creation; only deletion ordering (via Usage/ClusterUsage) is enforced when enableDeletionSequencing is true.
+	// Mutually exclusive with CreateOnly.
 	// +optional
 	DeleteOnly bool `json:"deleteOnly,omitempty"`
 

--- a/package/input/sequencer.fn.crossplane.io_inputs.yaml
+++ b/package/input/sequencer.fn.crossplane.io_inputs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: inputs.sequencer.fn.crossplane.io
 spec:
   group: sequencer.fn.crossplane.io
@@ -70,10 +70,17 @@ spec:
                     sequencing. Available variables: observed, desired, context (matching function-cel-filter conventions).
                     Example: observed.composite.resource.spec.enableFeatureX == true
                   type: string
+                createOnly:
+                  description: |-
+                    CreateOnly skips deletion sequencing for this rule.
+                    Creation ordering is still enforced, but no Usage/ClusterUsage resources are generated even when enableDeletionSequencing is true.
+                    Mutually exclusive with DeleteOnly.
+                  type: boolean
                 deleteOnly:
                   description: |-
                     DeleteOnly skips creation sequencing for this rule.
                     Resources are not blocked from creation; only deletion ordering (via Usage/ClusterUsage) is enforced when enableDeletionSequencing is true.
+                    Mutually exclusive with CreateOnly.
                   type: boolean
                 sequence:
                   description: Sequence is a list of composition resource names.
@@ -84,6 +91,9 @@ spec:
                     type: string
                   type: array
               type: object
+              x-kubernetes-validations:
+              - message: createOnly and deleteOnly are mutually exclusive
+                rule: '!(self.createOnly && self.deleteOnly)'
             type: array
           usageVersion:
             description: UsageVersion specifies the version of Usage/ClusterUsage


### PR DESCRIPTION
### Description of your changes

Add support to `createOnly` mode in individual sequence rules, similarly as what `deleteOnly` mode does, but to omit the deletion sequence (provided that feature is enabled).

Fixes: #165

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
